### PR TITLE
[POA-1089] Add check for bridge networking in 'ecs add' command

### DIFF
--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -520,6 +520,14 @@ func getTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 		return awf_error(errors.Errorf("Error while loading ECS task definition; please contact %s for assistance.", consts.SupportEmail))
 	}
 
+	// Check for bridge networking mode.
+	if output.NetworkMode == types.NetworkModeBridge {
+		printer.Errorf("This task definition is using bridge mode for networking which requires running Insights Agent as a daemon service. " +
+			"However, this is not currently supported by \"ecs add\" command. Please refer to documentation for running Insights Agent as a daemon service, " +
+			"https://learning.postman.com/docs/insights/insights-gs/#configure-the-insights-agent-as-a-daemon-service")
+		return awf_error(errors.Errorf("Error while validating ECS task definition; bridge networking not supported by \"ecs add\" command"))
+	}
+
 	wf.ecsTaskDefinition = output
 	wf.ecsTaskDefinitionARN = arn(aws.ToString(output.TaskDefinitionArn))
 	wf.ecsTaskDefinitionTags = tags

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -522,7 +522,7 @@ func getTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 
 	// Check for bridge networking mode.
 	if output.NetworkMode == types.NetworkModeBridge {
-		printer.Errorf("This task definition is using bridge mode for networking which requires running Insights Agent as a daemon service. " +
+		printer.Errorf("This task definition is using bridge mode for networking, which requires running Insights Agent as a daemon service. " +
 			"However, this is not currently supported by \"ecs add\" command. Please refer to documentation for running Insights Agent as a daemon service, " +
 			"https://learning.postman.com/docs/insights/insights-gs/#configure-the-insights-agent-as-a-daemon-service")
 		return awf_error(errors.Errorf("Error while validating ECS task definition; bridge networking not supported by \"ecs add\" command"))


### PR DESCRIPTION
Plan: https://postmanlabs.atlassian.net/wiki/spaces/PO/pages/5053218962/Plan+Insights+Agent+ECS+and+other+tasks+for+supporting+50+users#Alert-user-about-the-wrong-network-mode-in-ecs-add.1

Added bridge networking mode check in the `getTaskState()` function in the `ecs add` command and exit installation with proper error message 

---
Reviewers:
* Primary: @shreys7 
* Secondary: @mgritter 