### PR TITLE
[POA-527] Add apidump flags support in ecs command

### DIFF
--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -943,11 +944,29 @@ func makeAgentContainerDefinition(
 	addOptToEnv("POSTMAN_ECS_SERVICE", ecsService)
 	addOptToEnv("POSTMAN_ECS_TASK", ecsTaskDefinitionFamily)
 
+	// Pass apidump flags as it is, the apidump command will parse them.
+	// We are already handling the default values in apidump command
 	entryPoint := []string{
 		"/postman-insights-agent",
 		"apidump",
 		"--project",
 		projectId,
+		"--filter",
+		filterFlag,
+		"--host-allowlist",
+		strings.Join(hostAllowlistFlag, ","),
+		"--host-exclusions",
+		strings.Join(hostExclusionsFlag, ","),
+		"--interfaces",
+		strings.Join(interfacesFlag, ","),
+		"--path-allowlist",
+		strings.Join(pathAllowlistFlag, ","),
+		"--path-exclusions",
+		strings.Join(pathExclusionsFlag, ","),
+		"--rate-limit",
+		strconv.FormatFloat(rateLimitFlag, 'f', -1, 64),
+		"--stats-log-delay",
+		strconv.Itoa(statsLogDelay),
 	}
 
 	// XXX If we instantiate any new fields in the container definition here, we

--- a/cmd/internal/ecs/ecs.go
+++ b/cmd/internal/ecs/ecs.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"fmt"
 
+	"github.com/akitasoftware/akita-cli/apispec"
 	ecs_cloudformation_utils "github.com/akitasoftware/akita-cli/aws_utils/cloudformation/ecs"
 	ecs_console_utils "github.com/akitasoftware/akita-cli/aws_utils/console/ecs"
 	"github.com/akitasoftware/akita-cli/cmd/internal/cmderr"
@@ -38,6 +39,17 @@ var (
 
 	// Print out the steps that would be taken, but do not do them
 	dryRunFlag bool
+
+	// apidump flags
+	// These flags will be passed to apidump command in task definition file
+	filterFlag         string
+	hostAllowlistFlag  []string
+	hostExclusionsFlag []string
+	interfacesFlag     []string
+	pathAllowlistFlag  []string
+	pathExclusionsFlag []string
+	rateLimitFlag      float64
+	statsLogDelay      int
 )
 
 var Cmd = &cobra.Command{
@@ -114,6 +126,16 @@ func init() {
 	// Support for credentials in a nonstandard location
 	Cmd.PersistentFlags().StringVar(&awsCredentialsFlag, "aws-credentials", "", "Location of AWS credentials file.")
 	Cmd.PersistentFlags().MarkHidden("aws-credentials")
+
+	// initialize apidump flags as persistent flags for the ecs command
+	Cmd.PersistentFlags().StringVar(&filterFlag, "filter", "", "Used to match packets going to and coming from your API service.")
+	Cmd.PersistentFlags().StringSliceVar(&hostAllowlistFlag, "host-allow", nil, "Allows only HTTP hosts matching regular expressions.")
+	Cmd.PersistentFlags().StringSliceVar(&hostExclusionsFlag, "host-exclusions", nil, "Removes HTTP hosts matching regular expressions.")
+	Cmd.PersistentFlags().StringSliceVar(&interfacesFlag, "interfaces", nil, "List of network interfaces to listen on. Defaults to all interfaces on host.")
+	Cmd.PersistentFlags().StringSliceVar(&pathAllowlistFlag, "path-allow", nil, "Allows only HTTP paths matching regular expressions.")
+	Cmd.PersistentFlags().StringSliceVar(&pathExclusionsFlag, "path-exclusions", nil, "Removes HTTP paths matching regular expressions.")
+	Cmd.PersistentFlags().Float64Var(&rateLimitFlag, "rate-limit", apispec.DefaultRateLimit, "Number of requests per minute to capture.")
+	Cmd.PersistentFlags().IntVar(&statsLogDelay, "stats-log-delay", apispec.DefaultStatsLogDelay_seconds, "Print packet capture statistics after N seconds.")
 
 	Cmd.AddCommand(AddToECSCmd)
 	Cmd.AddCommand(PrintCloudFormationFragmentCmd)


### PR DESCRIPTION
Plan: https://postmanlabs.atlassian.net/wiki/spaces/PO/pages/5053218962/Plan+Insights+Agent+ECS+and+other+tasks+for+supporting+50+users

* Added support for the following eight flags: `filter`, `host-allow`, `host-exclusions`, `interfaces`, `path-allow`, `path-exclusions`, `rate-limit` and `stats-log-delay`.
* Added new vars and persistent flags for them
* Used these flags in `makeAgentContainerDefinition()` in `add.go` while constructing the entryPoint slice.
* These flags can also be used in all 3 sub-commands, i.e. `add`, `cf-fragment` and `task-def`

---

Reviewers:
* Primary: @shreys7 
* Secondary: @mgritter 