### PR TITLE
[POA-1809] Add bridge mode check in taskFlag function

### DIFF
--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -447,6 +447,14 @@ func (wf *AddWorkflow) loadTaskFromFlag() (nextState optionals.Optional[AddWorkf
 		}
 		return awf_error(errors.Wrap(describeErr, "Error loading task definition"))
 	}
+	// Check for bridge networking mode.
+	if output.NetworkMode == types.NetworkModeBridge {
+		printer.Errorf("This task definition is using bridge mode for networking, which requires running Insights Agent as a daemon service. " +
+			"However, this is not currently supported by \"ecs add\" command. Please refer to documentation for running Insights Agent as a daemon service, " +
+			"https://learning.postman.com/docs/insights/insights-gs/#configure-the-insights-agent-as-a-daemon-service\n")
+		return awf_error(errors.Errorf("Error while validating ECS task definition; bridge networking not supported by \"ecs add\" command"))
+	}
+
 	wf.ecsTaskDefinition = output
 	wf.ecsTaskDefinitionFamily = aws.ToString(output.Family)
 	wf.ecsTaskDefinitionARN = arn(aws.ToString(output.TaskDefinitionArn))
@@ -524,7 +532,7 @@ func getTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 	if output.NetworkMode == types.NetworkModeBridge {
 		printer.Errorf("This task definition is using bridge mode for networking, which requires running Insights Agent as a daemon service. " +
 			"However, this is not currently supported by \"ecs add\" command. Please refer to documentation for running Insights Agent as a daemon service, " +
-			"https://learning.postman.com/docs/insights/insights-gs/#configure-the-insights-agent-as-a-daemon-service")
+			"https://learning.postman.com/docs/insights/insights-gs/#configure-the-insights-agent-as-a-daemon-service\n")
 		return awf_error(errors.Errorf("Error while validating ECS task definition; bridge networking not supported by \"ecs add\" command"))
 	}
 

--- a/cmd/internal/ecs/add.go
+++ b/cmd/internal/ecs/add.go
@@ -533,7 +533,8 @@ func getTaskState(wf *AddWorkflow) (nextState optionals.Optional[AddWorkflowStat
 		printer.Errorf("This task definition is using bridge mode for networking, which requires running Insights Agent as a daemon service. " +
 			"However, this is not currently supported by \"ecs add\" command. Please refer to documentation for running Insights Agent as a daemon service, " +
 			"https://learning.postman.com/docs/insights/insights-gs/#configure-the-insights-agent-as-a-daemon-service\n")
-		return awf_error(errors.Errorf("Error while validating ECS task definition; bridge networking not supported by \"ecs add\" command"))
+		printer.Infof("Please select a different task definition, or hit Ctrl+C to exit.\n")
+		return awf_next(getTaskState)
 	}
 
 	wf.ecsTaskDefinition = output


### PR DESCRIPTION
We missed the bridge networking check in the `loadTaskFromFlag()` function, where we use the task value passed as the `--task` flag instead of asking interactively.
Also, if a user is running `ecs add` in interactive mode, ask for the task state again instead of erroring out.

Add the checks to this PR.